### PR TITLE
Add WHY_AM_I_HERE environment variable to base devcontainer configuration

### DIFF
--- a/config/devcontainer/devcontainer.json
+++ b/config/devcontainer/devcontainer.json
@@ -22,7 +22,8 @@
     "INIT_RESET_LIVE": "true",
     "INIT_LOGIN_GCP": "true",
     "INIT_LOGIN_GHCR": "false",
-    "INIT_LOGIN_CLOUDFLARE": "true"
+    "INIT_LOGIN_CLOUDFLARE": "true",
+    "WHY_AM_I_HERE": "true"
   },
   "mounts": [
     "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached",


### PR DESCRIPTION
This adds the WHY_AM_I_HERE environment variable to the base devcontainer.json configuration template. This environment variable is used to enable specific initialization behaviors in the container setup process.