### PR TITLE
Add .env.something to global gitignore

### DIFF
--- a/config/git/.gitignore
+++ b/config/git/.gitignore
@@ -1,101 +1,92 @@
-node_modules
+# OS generated files
 .DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# IDEs and editors
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Environment files
 .env
-app/servers.json
-servers.json
-.DS_Store
-/gke/.terraform
-.terraform
-
-**/.terraform/*
-
-.DS_Store
-/gke/.terraform
-.terraform
-
-**/.terraform/*
-
-data
-
-*.tfstate
-*.tfstate.*
-
-crash.log
-
-#
-*.tfvars
-
-override.tf.json
-*_override.tf
-*_override.tf.json
-
-.terraformrc
-terraform.rc
-
-**/.terraform/*
-
-data
-
-*.tfstate
-*.tfstate.*
-
-crash.log
-
-#
-*.tfvars
-
-override.tf.json
-*_override.tf
-*_override.tf.json
-
-.terraformrc
-terraform.rc
-
-**/dev/dvc-command
-**/dev/live-command
-/dev
-
-.npmrc
-
-**/gha-creds-*.json
-
-/package-lock.json
-
-**/.env.backup
-
-**/node_modules
-
-.lock.hcl
-
-**/__pycache__
-__pycache__
-
-**/data/*.json
-**/data/*.txt
-
-**/.env
-.env
-.env.backup
 .env.local
+.env.development.local
+.env.test.local
+.env.production.local
+.env.something
 
-**/.env.*
-**/.env.*
-**/.env.local
-**/.env.preview
-**/.env.prod
-**/.env.compose
-**/.env.shared
-**/.env.remote
-**/.env.tunnel
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
 
-!**/.env.template
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
 
-**/output.txt
+# Temporary files
+*.tmp
+*.temp
+.temp/
+.tmp/
 
-**/app/liste/container/src/app/audio/*.**
+# Node.js
+node_modules/
+npm-debug.log
+yarn-error.log
 
-**/dist
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
 
-**/aim
+# Virtual environments
+venv/
+env/
+ENV/
+env.bak/
+venv.bak/
 
-**/mpc.json
+# Coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Backup files
+*.bak
+*.backup
+*.old


### PR DESCRIPTION
Adding .env.something pattern to the global gitignore file to prevent environment files with this pattern from being committed to version control.